### PR TITLE
in render.py, generalize camelize() pattern to remove underscores between any two characters

### DIFF
--- a/djangorestframework_camel_case/render.py
+++ b/djangorestframework_camel_case/render.py
@@ -4,13 +4,13 @@ from collections import OrderedDict
 from rest_framework.renderers import JSONRenderer
 
 def underscoreToCamel(match):
-    return match.group()[0] + match.group()[2].upper()
+    return match.group(1) + match.group(2).upper()
 
 def camelize(data):
     if isinstance(data, dict):
         new_dict = OrderedDict()
         for key, value in data.items():
-            new_key = re.sub(r"._+.", underscoreToCamel, key)
+            new_key = re.sub(r"(.)_+(.)", underscoreToCamel, key)
             new_dict[new_key] = camelize(value)
         return new_dict
     if isinstance(data, (list, tuple)):


### PR DESCRIPTION
I recognize that converting to camel case may sometimes be ambiguous. But, I had some fields like,

title_245a_display
iuse3_count

where the underscores immediately before/after numbers weren't being removed during rendering (title_245aDisplay and iuse3_count). So I generalized the pattern in camelize() so that it displays these as title245aDisplay and iuse3Count. Initially I just added digits to the pattern, but after giving it a little more thought--I think generally camel case eschews underscores entirely, so it seemed appropriate to generalize the pattern to the point that it would work on any two characters separated by one or more underscores. Underscores at the beginning and end of a field name are still left alone.
