### PR TITLE
Settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,17 @@ Add the render and parser to your django settings file.
     }
     # ...
 
+By default the package uses `rest_framework.renderers.JSONRenderer`. If you want
+to use another renderer (the only possible alternative is
+`rest_framework.renderers.JSONRenderer`), you must specify it in your django 
+settings file.
+
+    # ...
+    JSON_CAMEL_CASE = {
+        'RENDERER_CLASS': 'rest_framework.renderers.UnicodeJSONRenderer'
+    }
+    # ...
+
 =============
 Running Tests
 =============

--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
-from rest_framework.parsers import JSONParser, ParseError, six
+from rest_framework.parsers import ParseError, six
 from django.conf import settings
+
+from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import underscoreize
 
 
-class CamelCaseJSONParser(JSONParser):
+class CamelCaseJSONParser(api_settings.PARSER_CLASS):
     def parse(self, stream, media_type=None, parser_context=None):
         parser_context = parser_context or {}
         encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)

--- a/djangorestframework_camel_case/render.py
+++ b/djangorestframework_camel_case/render.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from rest_framework.renderers import JSONRenderer
+from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import camelize
 
 
-class CamelCaseJSONRenderer(JSONRenderer):
+class CamelCaseJSONRenderer(api_settings.RENDERER_CLASS):
     def render(self, data, *args, **kwargs):
         return super(CamelCaseJSONRenderer, self).render(camelize(data), *args,
                                                          **kwargs)

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from rest_framework.settings import APISettings
+
+
+USER_SETTINGS = getattr(settings, 'JSON_CAMEL_CASE', None)
+
+DEFAULTS = {
+    'RENDERER_CLASS': 'rest_framework.renderers.JSONRenderer',
+    'PARSER_CLASS': 'rest_framework.parsers.JSONParser'
+}
+
+# List of settings that may be in string import notation.
+IMPORT_STRINGS = (
+    'RENDERER_CLASS',
+    'PARSER_CLASS'
+)
+
+VALID_SETTINGS = {
+    'RENDERER_CLASS': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.UnicodeJSONRenderer',
+    ),
+    'PARSER_CLASS': (
+        'rest_framework.parsers.JSONParser',
+    )
+}
+
+def validate_settings(input_settings, valid_settings):
+    for setting_name, valid_values in valid_settings.iteritems():
+        input_setting = input_settings.get(setting_name)
+        if input_setting and input_setting not in valid_values:
+            raise ImproperlyConfigured(setting_name)
+
+validate_settings(USER_SETTINGS, VALID_SETTINGS)
+
+api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)


### PR DESCRIPTION
I wanted to use `rest_framework.renderers.UnicodeJSONRenderer` with camel case names,
but in the package `rest_framework.renderers.JSONRenderer` was hardcoded.
So I made it configurable.
