### PR TITLE
Add capability to camelize QuerySets

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 import re
 
+from django.db.models import QuerySet
+
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
 
@@ -20,6 +22,11 @@ def camelize(data):
         for i in range(len(data)):
             data[i] = camelize(data[i])
         return data
+    if isinstance(data, QuerySet):
+        new_list = []
+        for i in range(len(data)):
+            new_list.append(camelize(data[i]))
+        return new_list
     return data
 
 


### PR DESCRIPTION
This PR is intended to add support when one is using  `.values()` method on querysets. Actual behaviour is returning the QuerySet since it's not a dict, a list neither a tuple. Now a ValuesQuerySet (deprecated from 1.9, for this reason I check straight for QuerySet instance) can be camelized correctly.

Since there is no django setup while running tests I'm not sure how to test it, but if you have any suggestion @vbabiy I'd be happy to add tests for this case