### PR TITLE
Fixes rendering of tuple values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Hidden files
+.*
+
 *.py[cod]
 
 # C extensions

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -16,10 +16,15 @@ def camelize(data):
             new_key = re.sub(r"[a-z]_[a-z]", underscoreToCamel, key)
             new_dict[new_key] = camelize(value)
         return new_dict
-    if isinstance(data, (list, tuple)):
+    if isinstance(data, list):
         for i in range(len(data)):
             data[i] = camelize(data[i])
         return data
+    if isinstance(data, tuple):
+        camelized_data = []
+        for i in range(len(data)):
+            camelized_data.append(camelize(data[i]))
+        return tuple(camelized_data)
     return data
 
 

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -24,7 +24,7 @@ def camelize(data):
         camelized_data = []
         for i in range(len(data)):
             camelized_data.append(camelize(data[i]))
-        return tuple(camelized_data)
+        return camelized_data
     return data
 
 

--- a/tests.py
+++ b/tests.py
@@ -22,7 +22,7 @@ class UnderscoreToCamelTestCase(TestCase):
             "multiple_values" : (1, 2)
         }
         output = {
-            "multipleValues": (1, 2)
+            "multipleValues": [1, 2]
         }
         self.assertEqual(camelize(input), output)
 

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ from djangorestframework_camel_case.util import camelize, underscoreize
 
 
 class UnderscoreToCamelTestCase(TestCase):
+
     def test_under_to_camel(self):
         input = {
             "title_display": 1
@@ -16,6 +17,14 @@ class UnderscoreToCamelTestCase(TestCase):
         }
         self.assertEqual(camelize(input), output)
 
+    def test_tuples(self):
+        input = {
+            "multiple_values" : (1, 2)
+        }
+        output = {
+            "multipleValues": (1, 2)
+        }
+        self.assertEqual(camelize(input), output)
 
 class CamelToUnderscoreTestCase(TestCase):
     def test_under_to_camel(self):


### PR DESCRIPTION
Hi,
if we don't store the values in a temporary list an error will be raised. We cannot do an inplace replacement since tuples are immutable. I added a testcase to cover the issue.

Regards
Jakob
