### PR TITLE
Bug in conversion of list/tuple

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -1,42 +1,33 @@
+import inflection
 from collections import OrderedDict
-import re
-
-first_cap_re = re.compile('(.)([A-Z][a-z]+)')
-all_cap_re = re.compile('([a-z0-9])([A-Z])')
-
-
-def underscoreToCamel(match):
-    return match.group()[0] + match.group()[2].upper()
 
 
 def camelize(data):
     if isinstance(data, dict):
         new_dict = OrderedDict()
-        for key, value in data.items():
-            new_key = re.sub(r"[a-z]_[a-z]", underscoreToCamel, key)
-            new_dict[new_key] = camelize(value)
+
+        for k, v in data.items():
+            new_dict[inflection.camelize(k, uppercase_first_letter=False)] = camelize(v)
+
         return new_dict
-    if isinstance(data, (list, tuple)):
-        for i in range(len(data)):
-            data[i] = camelize(data[i])
-        return data
+
+    if isinstance(data, list):
+        return [camelize(x) for x in data]
+
+    if isinstance(data, tuple):
+        return tuple(camelize(x) for x in data)
+
     return data
-
-
-def camel_to_underscore(name):
-    s1 = first_cap_re.sub(r'\1_\2', name)
-    return all_cap_re.sub(r'\1_\2', s1).lower()
 
 
 def underscoreize(data):
     if isinstance(data, dict):
-        new_dict = {}
-        for key, value in data.items():
-            new_key = camel_to_underscore(key)
-            new_dict[new_key] = underscoreize(value)
-        return new_dict
-    if isinstance(data, (list, tuple)):
-        for i in range(len(data)):
-            data[i] = underscoreize(data[i])
-        return data
+        return {inflection.underscore(k): underscoreize(v) for k, v in data.items()}
+
+    if isinstance(data, list):
+        return [underscoreize(x) for x in data]
+
+    if isinstance(data, tuple):
+        return tuple(underscoreize(x) for x in data)
+
     return data

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -1,5 +1,49 @@
-import inflection
+import re
+
 from collections import OrderedDict
+
+
+def camelize_key(string, uppercase_first_letter=True):
+    """
+    From: https://github.com/jpvanhal/inflection
+
+    Convert strings to CamelCase.
+    Examples::
+        >>> camelize("device_type")
+        "DeviceType"
+        >>> camelize("device_type", False)
+        "deviceType"
+    :func:`camelize` can be though as a inverse of :func:`underscore`, although
+    there are some cases where that does not hold::
+        >>> camelize(underscore("IOError"))
+        "IoError"
+    :param uppercase_first_letter: if set to `True` :func:`camelize` converts
+        strings to UpperCamelCase. If set to `False` :func:`camelize` produces
+        lowerCamelCase. Defaults to `True`.
+    """
+    if uppercase_first_letter:
+        return re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), string)
+    else:
+        return string[0].lower() + camelize_key(string)[1:]
+
+
+def underscore_key(string):
+    """
+    From: https://github.com/jpvanhal/inflection
+
+    Make an underscored, lowercase form from the expression in the string.
+    Example::
+        >>> underscore("DeviceType")
+        "device_type"
+    As a rule of thumb you can think of :func:`underscore` as the inverse of
+    :func:`camelize`, though there are cases where that does not hold::
+        >>> camelize(underscore("IOError"))
+        "IoError"
+    """
+    string = re.sub(r"([A-Z]+)([A-Z][a-z])", r'\1_\2', string)
+    string = re.sub(r"([a-z\d])([A-Z])", r'\1_\2', string)
+    string = string.replace("-", "_")
+    return string.lower()
 
 
 def camelize(data):
@@ -7,7 +51,7 @@ def camelize(data):
         new_dict = OrderedDict()
 
         for k, v in data.items():
-            new_dict[inflection.camelize(k, uppercase_first_letter=False)] = camelize(v)
+            new_dict[camelize_key(k, False)] = camelize(v)
 
         return new_dict
 
@@ -22,7 +66,10 @@ def camelize(data):
 
 def underscoreize(data):
     if isinstance(data, dict):
-        return {inflection.underscore(k): underscoreize(v) for k, v in data.items()}
+        new_dict = dict()
+        for key, value in data.items():
+            new_dict[underscore_key(key)] = underscoreize(value)
+        return new_dict
 
     if isinstance(data, list):
         return [underscoreize(x) for x in data]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 djangorestframework>=2.0.0
+inflection>=0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 djangorestframework>=2.0.0
-inflection>=0.2.1

--- a/tests.py
+++ b/tests.py
@@ -30,9 +30,9 @@ class UnderscoreToCamelTestCase(TestCase):
         self.assertIsNot(result, input, "should not change original list")
 
     def test_under_to_camel_tuple(self):
-        input = ( 
+        input = (
             {"title_display": 1},
-        ) 
+        )
         output = (
             {"titleDisplay": 1},
         )

--- a/tests.py
+++ b/tests.py
@@ -7,23 +7,97 @@ from djangorestframework_camel_case.util import camelize, underscoreize
 
 
 class UnderscoreToCamelTestCase(TestCase):
-    def test_under_to_camel(self):
+    def test_under_to_camel_dict(self):
         input = {
             "title_display": 1
         }
         output = {
             "titleDisplay": 1
+        }
+        result = camelize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original dict")
+
+    def test_under_to_camel_list(self):
+        input = [
+            {"title_display": 1}
+        ]
+        output = [
+            {"titleDisplay": 1}
+        ]
+        result = camelize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original list")
+
+    def test_under_to_camel_tuple(self):
+        input = ( 
+            {"title_display": 1},
+        ) 
+        output = (
+            {"titleDisplay": 1},
+        )
+        result = camelize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original tuple")
+
+    def test_under_to_camel_nested(self):
+        input = {
+            "title_display": 1,
+            "a_list": [1, "two_three", {"three_four": 5}],
+            "a_tuple": ("one_two", 3)
+        }
+        output = {
+            "titleDisplay": 1,
+            "aList": [1, "two_three", {"threeFour": 5}],
+            "aTuple": ("one_two", 3)
         }
         self.assertEqual(camelize(input), output)
 
 
 class CamelToUnderscoreTestCase(TestCase):
-    def test_under_to_camel(self):
+    def test_camel_to_under_dict(self):
         input = {
             "titleDisplay": 1
         }
         output = {
             "title_display": 1
+        }
+        result = underscoreize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original dict")
+
+    def test_camel_to_under_list(self):
+        input = [
+            {"titleDisplay": 1}
+        ]
+        output = [
+            {"title_display": 1}
+        ]
+        result = underscoreize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original list")
+
+    def test_camel_to_under_tuple(self):
+        input = [
+            {"titleDisplay": 1}
+        ]
+        output = [
+            {"title_display": 1}
+        ]
+        result = underscoreize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original tuple")
+
+    def test_camel_to_under_nested(self):
+        input = {
+            "titleDisplay": 1,
+            "aList": [1, "two_three", {"threeFour": 5}],
+            "aTuple": ("one_two", 3)
+        }
+        output = {
+            "title_display": 1,
+            "a_list": [1, "two_three", {"three_four": 5}],
+            "a_tuple": ("one_two", 3)
         }
         self.assertEqual(underscoreize(input), output)
 
@@ -31,6 +105,8 @@ class CamelToUnderscoreTestCase(TestCase):
 class CompatibilityTest(TestCase):
     def test_compatibility(self):
         input = {
-            "title_245a_display": 1
+            "title_display": 1,
+            "a_list": [1, "two_three", {"three_four": 5}],
+            "a_tuple": ("one_two", 3)
         }
         self.assertEqual(underscoreize(camelize(input)), input)


### PR DESCRIPTION
@vbabiy 

There is a bug in serialization of list/tuple.

List is modified in place, which caused bugs later down the DRF flow.
Tuples cannot be modified at all, so the code throws exceptions if tuples are present.

Also added tests for these case.

Thanks @butschi for the first inflection based code.
