### PR TITLE
Fix TypeError when data is a tuple

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -17,9 +17,8 @@ def camelize(data):
             new_dict[new_key] = camelize(value)
         return new_dict
     if isinstance(data, (list, tuple)):
-        for i in range(len(data)):
-            data[i] = camelize(data[i])
-        return data
+        data_type = type(data)
+        return data_type(map(camelize, data))
     return data
 
 
@@ -36,7 +35,6 @@ def underscoreize(data):
             new_dict[new_key] = underscoreize(value)
         return new_dict
     if isinstance(data, (list, tuple)):
-        for i in range(len(data)):
-            data[i] = underscoreize(data[i])
-        return data
+        data_type = type(data)
+        return data_type(map(underscoreize, data))
     return data

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -16,9 +16,12 @@ def camelize(data):
             new_key = re.sub(r"[a-z]_[a-z]", underscoreToCamel, key)
             new_dict[new_key] = camelize(value)
         return new_dict
-    if isinstance(data, (list, tuple)):
-        data_type = type(data)
-        return data_type(map(camelize, data))
+    if isinstance(data, list):
+        for i in range(len(data)):
+            data[i] = camelize(data[i])
+        return data
+    if isinstance(data, tuple):
+        return tuple(map(camelize, data))
     return data
 
 
@@ -34,7 +37,10 @@ def underscoreize(data):
             new_key = camel_to_underscore(key)
             new_dict[new_key] = underscoreize(value)
         return new_dict
-    if isinstance(data, (list, tuple)):
-        data_type = type(data)
-        return data_type(map(underscoreize, data))
+    if isinstance(data, list):
+        for i in range(len(data)):
+            data[i] = underscoreize(data[i])
+        return data
+    if isinstance(data, tuple):
+        return tuple(map(underscoreize, data))
     return data


### PR DESCRIPTION
Tuples do not support item assignment so instead this will copy the data in the case of a tuple.

I first tried it with both list and tuple but that failed in the case of the list being a derived type of `rest_framework.utils.serializer_helpers.ReturnList`.
