### PR TITLE
Fix code block rendering in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ At the command line::
 
 Add the render and parser to your django settings file.
 
-.. sourcecode:: python
+.. code-block:: python
 
     # ...
     REST_FRAMEWORK = {

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ At the command line::
 
 Add the render and parser to your django settings file.
 
+.. sourcecode:: python
+
     # ...
     REST_FRAMEWORK = {
 
@@ -47,6 +49,8 @@ To run the current test suite, execute the following from the root of he project
 
     $ python -m unittest discover
 
+=============
+License
+=============
 
-
-* Free software: BSD license
+Free software: BSD license


### PR DESCRIPTION
In contrast to Markdown, in RST code formatting can't be introduced simply by indenting.
