### PR TITLE
Fix for keys of non-string types

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 import re
+import sys
+PY_VERISON = sys.version_info[0]
 
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
@@ -13,7 +15,10 @@ def camelize(data):
     if isinstance(data, dict):
         new_dict = OrderedDict()
         for key, value in data.items():
-            new_key = re.sub(r"[a-z]_[a-z]", underscoreToCamel, key)
+            if isinstance(key, (str if PY_VERISON >= 3 else basestring)):
+                new_key = re.sub(r"[a-z]_[a-z]", underscoreToCamel, key)
+            else:
+                new_key = key
             new_dict[new_key] = camelize(value)
         return new_dict
     if isinstance(data, (list, tuple)):
@@ -32,7 +37,10 @@ def underscoreize(data):
     if isinstance(data, dict):
         new_dict = {}
         for key, value in data.items():
-            new_key = camel_to_underscore(key)
+            if isinstance(key, six.string_types):
+                new_key = camel_to_underscore(key)
+            else:
+                new_key = key
             new_dict[new_key] = underscoreize(value)
         return new_dict
     if isinstance(data, (list, tuple)):

--- a/tests.py
+++ b/tests.py
@@ -34,3 +34,8 @@ class CompatibilityTest(TestCase):
             "title_245a_display": 1
         }
         self.assertEqual(underscoreize(camelize(input)), input)
+
+class NonStringKeyTest(TestCase):
+    def test_non_string_key(self):
+        input = {1: "test"}
+        self.assertEqual(underscoreize(camelize(input)), input)


### PR DESCRIPTION
This will skip all keys that are not strings (i..e numbers)

This fixes #29 