### PR TITLE
Allow no underscore before number when Underscoreizing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,39 @@ settings file.
     }
     # ...
 
+=====================
+Underscoreize Options
+=====================
+
+As raised in https://github.com/krasa/StringManipulation/issues/8#issuecomment-121203018
+there are two conventions of snake case.
+
+.. code-block:: none
+
+    # Case 1 (Package default)
+    v2Counter -> v_2_counter
+    fooBar2 -> foo_bar_2
+
+    # Case 2
+    v2Counter -> v2_counter
+    fooBar2 -> foo_bar2
+
+
+By default, the package uses the first case. To use the second case, specify it in your django settings file.
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        'JSON_UNDERSCOREIZE': {
+            'no_underscore_before_number': True,
+        },
+        # ...
+    }
+
+
+
+
 =============
 Running Tests
 =============

--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -15,6 +15,9 @@ class CamelCaseJSONParser(api_settings.PARSER_CLASS):
 
         try:
             data = stream.read().decode(encoding)
-            return underscoreize(json.loads(data))
+            return underscoreize(
+                json.loads(data),
+                **api_settings.JSON_UNDERSCOREIZE
+            )
         except ValueError as exc:
             raise ParseError('JSON parse error - %s' % six.text_type(exc))

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -9,7 +9,11 @@ USER_SETTINGS = getattr(settings, 'JSON_CAMEL_CASE', {})
 
 DEFAULTS = {
     'RENDERER_CLASS': 'rest_framework.renderers.JSONRenderer',
-    'PARSER_CLASS': 'rest_framework.parsers.JSONParser'
+    'PARSER_CLASS': 'rest_framework.parsers.JSONParser',
+
+    'JSON_UNDERSCOREIZE': {
+        'no_underscore_before_number': False,
+    },
 }
 
 # List of settings that may be in string import notation.

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -3,8 +3,6 @@ from collections import OrderedDict
 
 from django.utils import six
 
-first_cap_re = re.compile(r'(.)([A-Z]|[0-9]+)')
-all_cap_re = re.compile(r'([a-z]|[0-9]+[a-z]?|[A-Z]?)([A-Z0-9])')
 camelize_re = re.compile(r"[a-z0-9]?_[a-z0-9]")
 
 
@@ -31,22 +29,31 @@ def camelize(data):
     return data
 
 
-def camel_to_underscore(name):
-    return all_cap_re.sub(r'\1_\2', name).lower()
+def get_underscoreize_re(options):
+    if options.get('no_underscore_before_number'):
+        pattern = r'([a-z]|[0-9]+[a-z]?|[A-Z]?)([A-Z])'
+    else:
+        pattern = r'([a-z]|[0-9]+[a-z]?|[A-Z]?)([A-Z0-9])'
+    return re.compile(pattern)
 
 
-def underscoreize(data):
+def camel_to_underscore(name, **options):
+    underscoreize_re = get_underscoreize_re(options)
+    return underscoreize_re.sub(r'\1_\2', name).lower()
+
+
+def underscoreize(data, **options):
     if isinstance(data, dict):
         new_dict = {}
         for key, value in data.items():
             if isinstance(key, six.string_types):
-                new_key = camel_to_underscore(key)
+                new_key = camel_to_underscore(key, **options)
             else:
                 new_key = key
-            new_dict[new_key] = underscoreize(value)
+            new_dict[new_key] = underscoreize(value, **options)
         return new_dict
     if is_iterable(data) and not isinstance(data, six.string_types):
-        return [underscoreize(item) for item in data]
+        return [underscoreize(item, **options) for item in data]
 
     return data
 

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,7 @@ class UnderscoreToCamelTestCase(TestCase):
             "b_only_one_letter": 5,
             "only_c_letter": 6,
             "mix_123123a_and_letters": 7,
+            "no_underscore_before123": 8
         }
         output = {
             "twoWord": 1,
@@ -24,7 +25,8 @@ class UnderscoreToCamelTestCase(TestCase):
             "onlyOneLetterA": 4,
             "bOnlyOneLetter": 5,
             "onlyCLetter": 6,
-            "mix123123aAndLetters": 7
+            "mix123123aAndLetters": 7,
+            "noUnderscoreBefore123": 8
         }
         self.assertEqual(camelize(data), output)
 
@@ -70,6 +72,12 @@ class CamelToUnderscoreTestCase(TestCase):
             "mix_123123a_and_letters": 7
         }
         self.assertEqual(underscoreize(data), output)
+
+    def test_camel_to_under_keys_with_no_underscore_before_number(self):
+        data = {'noUnderscoreBefore123': 1}
+        output = {'no_underscore_before123': 1}
+        options = {'no_underscore_before_number': True}
+        self.assertEqual(underscoreize(data, **options), output)
 
     def test_under_to_camel_input_untouched_for_sequence(self):
         data = [


### PR DESCRIPTION
The package is now by default underscoreizing keys in this way:
```
v2Counter -> v_2_counter
fooBar2 -> foo_bar_2
```

But, i would like it to be
```
v2Counter -> v2_counter
fooBar2 -> foo_bar2
```

I guess both two ways are acceptable and common for snake case. So this PR is intended to cover both of them.