### PR TITLE
Little update in documentation concerning UnicodeJSONRenderer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Swapping Renderer
 
 By default the package uses `rest_framework.renderers.JSONRenderer`. If you want
 to use another renderer (the only possible alternative is
-`rest_framework.renderers.UnicodeJSONRenderer`), you must specify it in your django
+`rest_framework.renderers.UnicodeJSONRenderer`, only available in DRF < 3.0), you must specify it in your django
 settings file.
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Swapping Renderer
 
 By default the package uses `rest_framework.renderers.JSONRenderer`. If you want
 to use another renderer (the only possible alternative is
-`rest_framework.renderers.JSONRenderer`), you must specify it in your django
+`rest_framework.renderers.UnicodeJSONRenderer`), you must specify it in your django
 settings file.
 
 .. code-block:: python


### PR DESCRIPTION
`JSONRenderer` should be `UnicodeJSONRenderer` in documentation.

`UnicodeJSONRenderer` is [removed since DRF 3.0](http://www.django-rest-framework.org/topics/3.0-announcement/#unicode-json-by-default)