### PR TITLE
Add json_underscoreize as CamelCaseJSONParser class attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,20 @@ By default, the package uses the first case. To use the second case, specify it 
         # ...
     }
 
+Alternatively, you can change this behavior on a class level by setting `json_underscoreize`:
 
+.. code-block:: python
 
+    from djangorestframework_camel_case.parser import CamelCaseJSONParser
+    from rest_framework.generics import CreateAPIView
+
+    class NoUnderscoreBeforeNumberCamelCaseJSONParser(CamelCaseJSONParser):
+        json_underscoreize = {'no_underscore_before_number': True}
+
+    class MyView(CreateAPIView):
+        queryset = MyModel.objects.all()
+        serializer_class = MySerializer
+        parser_classes = (NoUnderscoreBeforeNumberCamelCaseJSONParser,)
 
 =============
 Running Tests

--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -9,15 +9,14 @@ from djangorestframework_camel_case.util import underscoreize
 
 
 class CamelCaseJSONParser(api_settings.PARSER_CLASS):
+    'json_underscoreize' = api_settings.JSON_UNDERSCOREIZE
+
     def parse(self, stream, media_type=None, parser_context=None):
         parser_context = parser_context or {}
         encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
 
         try:
             data = stream.read().decode(encoding)
-            return underscoreize(
-                json.loads(data),
-                **api_settings.JSON_UNDERSCOREIZE
-            )
+            return underscoreize(json.loads(data), **self.json_underscoreize)
         except ValueError as exc:
             raise ParseError('JSON parse error - %s' % six.text_type(exc))

--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -9,7 +9,7 @@ from djangorestframework_camel_case.util import underscoreize
 
 
 class CamelCaseJSONParser(api_settings.PARSER_CLASS):
-    'json_underscoreize' = api_settings.JSON_UNDERSCOREIZE
+    json_underscoreize = api_settings.JSON_UNDERSCOREIZE
 
     def parse(self, stream, media_type=None, parser_context=None):
         parser_context = parser_context or {}


### PR DESCRIPTION
I need more flexibility concerning the underscore and numbers, because I'm using several third-party packages in my project. As a result, I have some fields with and some without and underscore before the number (e.g. `field_1` and `field2`).

My solution to this is to be able to choose on a class level which behavior should to use.

I'd appreciate if you could merge this PR before you release the next version.

I'm happy to add some documentation… Just let me know.