### PR TITLE
Fix upstream changes from DRF-3.10

### DIFF
--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
-import six
 from django.conf import settings
 from django.http.multipartparser import (
     MultiPartParser as DjangoMultiPartParser,
     MultiPartParserError,
 )
 from rest_framework.exceptions import ParseError
+from rest_framework.parsers import FormParser
 from rest_framework.parsers import MultiPartParser, DataAndFiles
-from rest_framework.parsers import six, FormParser
-
 from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import underscoreize
 
@@ -24,7 +22,7 @@ class CamelCaseJSONParser(api_settings.PARSER_CLASS):
             data = stream.read().decode(encoding)
             return underscoreize(json.loads(data), **api_settings.JSON_UNDERSCOREIZE)
         except ValueError as exc:
-            raise ParseError("JSON parse error - %s" % six.text_type(exc))
+            raise ParseError("JSON parse error - %s" % str(exc))
 
 
 class CamelCaseFormParser(FormParser):
@@ -69,4 +67,4 @@ class CamelCaseMultiPartParser(MultiPartParser):
                 underscoreize(files, **api_settings.JSON_UNDERSCOREIZE),
             )
         except MultiPartParserError as exc:
-            raise ParseError("Multipart form parse error - %s" % six.text_type(exc))
+            raise ParseError("Multipart form parse error - %s" % str(exc))

--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 import json
 
+import six
 from django.conf import settings
 from django.http.multipartparser import (
     MultiPartParser as DjangoMultiPartParser,
     MultiPartParserError,
 )
+
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import FormParser
 from rest_framework.parsers import MultiPartParser, DataAndFiles
+
 from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import underscoreize
 
@@ -22,7 +25,7 @@ class CamelCaseJSONParser(api_settings.PARSER_CLASS):
             data = stream.read().decode(encoding)
             return underscoreize(json.loads(data), **api_settings.JSON_UNDERSCOREIZE)
         except ValueError as exc:
-            raise ParseError("JSON parse error - %s" % str(exc))
+            raise ParseError("JSON parse error - %s" % six.text_type(exc))
 
 
 class CamelCaseFormParser(FormParser):
@@ -67,4 +70,4 @@ class CamelCaseMultiPartParser(MultiPartParser):
                 underscoreize(files, **api_settings.JSON_UNDERSCOREIZE),
             )
         except MultiPartParserError as exc:
-            raise ParseError("Multipart form parse error - %s" % str(exc))
+            raise ParseError("Multipart form parse error - %s" % six.text_type(exc))

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 from django.core.files import File
 from django.http import QueryDict
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
@@ -27,13 +26,13 @@ def camelize(data):
         for key, value in data.items():
             if isinstance(key, Promise):
                 key = force_text(key)
-            if isinstance(key, six.string_types) and "_" in key:
+            if isinstance(key, str) and "_" in key:
                 new_key = re.sub(camelize_re, underscore_to_camel, key)
             else:
                 new_key = key
             new_dict[new_key] = camelize(value)
         return new_dict
-    if is_iterable(data) and not isinstance(data, six.string_types):
+    if is_iterable(data) and not isinstance(data, str):
         return [camelize(item) for item in data]
     return data
 
@@ -62,7 +61,7 @@ def underscoreize(data, **options):
     if isinstance(data, dict):
         new_dict = {}
         for key, value in _get_iterable(data):
-            if isinstance(key, six.string_types):
+            if isinstance(key, str):
                 new_key = camel_to_underscore(key, **options)
             else:
                 new_key = key
@@ -74,7 +73,7 @@ def underscoreize(data, **options):
                 new_query.setlist(key, value)
             return new_query
         return new_dict
-    if is_iterable(data) and not isinstance(data, (six.string_types, File)):
+    if is_iterable(data) and not isinstance(data, (str, File)):
         return [underscoreize(item, **options) for item in data]
 
     return data

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -1,4 +1,5 @@
 import re
+import six
 from collections import OrderedDict
 
 from django.core.files import File
@@ -26,13 +27,13 @@ def camelize(data):
         for key, value in data.items():
             if isinstance(key, Promise):
                 key = force_text(key)
-            if isinstance(key, str) and "_" in key:
+            if isinstance(key, six.string_types) and "_" in key:
                 new_key = re.sub(camelize_re, underscore_to_camel, key)
             else:
                 new_key = key
             new_dict[new_key] = camelize(value)
         return new_dict
-    if is_iterable(data) and not isinstance(data, str):
+    if is_iterable(data) and not isinstance(data, six.string_types):
         return [camelize(item) for item in data]
     return data
 
@@ -61,7 +62,7 @@ def underscoreize(data, **options):
     if isinstance(data, dict):
         new_dict = {}
         for key, value in _get_iterable(data):
-            if isinstance(key, str):
+            if isinstance(key, six.string_types):
                 new_key = camel_to_underscore(key, **options)
             else:
                 new_key = key
@@ -73,7 +74,7 @@ def underscoreize(data, **options):
                 new_query.setlist(key, value)
             return new_query
         return new_dict
-    if is_iterable(data) and not isinstance(data, (str, File)):
+    if is_iterable(data) and not isinstance(data, (six.string_types, File)):
         return [underscoreize(item, **options) for item in data]
 
     return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 djangorestframework>=2.0.0
 django>=1.8
+six>=1.10.0


### PR DESCRIPTION
DRF has dropped python 2 support with version 3.10 and Django has dropped it in [master](https://github.com/django/django/commit/41384812efe209c8295a50d78b45e0ffb2992436). If this lib wants to keep compatibility it needs to pull out six support into `requirements.txt` as it cannot import `six` from new `rest_framework` versions. 

PR #59 had the right idea, but `from django.util import six` will also not be available anymore


