### PR TITLE
Cleanup six imports

### DIFF
--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
-import six
 from django.conf import settings
 from django.http.multipartparser import (
     MultiPartParser as DjangoMultiPartParser,
     MultiPartParserError,
 )
+from django.util import six
 from rest_framework.exceptions import ParseError
-from rest_framework.parsers import MultiPartParser, DataAndFiles
-from rest_framework.parsers import six, FormParser
+from rest_framework.parsers import MultiPartParser, DataAndFiles, FormParser
 
 from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import underscoreize


### PR DESCRIPTION
There is no requirement on six, so we cannot trust it to be just there.
We also do *not* want to import six from djangorestframework, since it is not part of djangorestframework's API.
Therefore, we always want to import six from `django.utils`, where it is guaranteed to exist.