### PR TITLE
Fix the underscoreize pattern. #62

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -41,7 +41,7 @@ def get_underscoreize_re(options):
     if options.get("no_underscore_before_number"):
         pattern = r"([a-z]|[0-9]+[a-z]?|[A-Z]?)([A-Z])"
     else:
-        pattern = r"([a-z]|[0-9]+[a-z]?|[A-Z]?)([A-Z0-9])"
+        pattern = r"([a-z]|[0-9]+[a-z]+|[A-Z]?)([A-Z]|[0-9]+)"
     return re.compile(pattern)
 
 

--- a/tests.py
+++ b/tests.py
@@ -71,6 +71,9 @@ class CamelToUnderscoreTestCase(TestCase):
             "bOnlyOneLetter": 5,
             "onlyCLetter": 6,
             "mix123123aAndLetters": 7,
+            "key10": 8,
+            "anotherKey10": 9,
+            "optionS10": 10,
         }
         output = {
             "two_word": 1,
@@ -80,6 +83,9 @@ class CamelToUnderscoreTestCase(TestCase):
             "b_only_one_letter": 5,
             "only_c_letter": 6,
             "mix_123123a_and_letters": 7,
+            "key_10": 8,
+            "another_key_10": 9,
+            "option_s_10": 10,
         }
         self.assertEqual(underscoreize(data), output)
 


### PR DESCRIPTION
CamelCaseJSONParser does not care about the pattern which ends with more than one digit.
See https://github.com/vbabiy/djangorestframework-camel-case/issues/62.