### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@
 language: python
 
 python:
-  - "3.6"
-  - "2.7"
-  - "pypy"
+  - "3.7"
+  - "pypy3.5"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements.txt

--- a/djangorestframework_camel_case/__init__.py
+++ b/djangorestframework_camel_case/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 __author__ = "Vitaly Babiy"
 __email__ = "vbabiy86@gmail.com"
 __version__ = "1.0.3"

--- a/djangorestframework_camel_case/parser.py
+++ b/djangorestframework_camel_case/parser.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 import json
 
-import six
 from django.conf import settings
 from django.http.multipartparser import (
     MultiPartParser as DjangoMultiPartParser,
@@ -9,7 +7,7 @@ from django.http.multipartparser import (
 )
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import MultiPartParser, DataAndFiles
-from rest_framework.parsers import six, FormParser
+from rest_framework.parsers import FormParser
 
 from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import underscoreize
@@ -24,7 +22,7 @@ class CamelCaseJSONParser(api_settings.PARSER_CLASS):
             data = stream.read().decode(encoding)
             return underscoreize(json.loads(data), **api_settings.JSON_UNDERSCOREIZE)
         except ValueError as exc:
-            raise ParseError("JSON parse error - %s" % six.text_type(exc))
+            raise ParseError("JSON parse error - %s" % str(exc))
 
 
 class CamelCaseFormParser(FormParser):
@@ -34,7 +32,7 @@ class CamelCaseFormParser(FormParser):
 
     def parse(self, stream, media_type=None, parser_context=None):
         return underscoreize(
-            super(CamelCaseFormParser, self).parse(stream, media_type, parser_context),
+            super().parse(stream, media_type, parser_context),
             **api_settings.JSON_UNDERSCOREIZE
         )
 
@@ -69,4 +67,4 @@ class CamelCaseMultiPartParser(MultiPartParser):
                 underscoreize(files, **api_settings.JSON_UNDERSCOREIZE),
             )
         except MultiPartParserError as exc:
-            raise ParseError("Multipart form parse error - %s" % six.text_type(exc))
+            raise ParseError("Multipart form parse error - %s" % str(exc))

--- a/djangorestframework_camel_case/render.py
+++ b/djangorestframework_camel_case/render.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 from djangorestframework_camel_case.settings import api_settings
 from djangorestframework_camel_case.util import camelize
 
 
 class CamelCaseJSONRenderer(api_settings.RENDERER_CLASS):
     def render(self, data, *args, **kwargs):
-        return super(CamelCaseJSONRenderer, self).render(
+        return super().render(
             camelize(data), *args, **kwargs
         )

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 from django.core.files import File
 from django.http import QueryDict
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
@@ -27,13 +26,13 @@ def camelize(data):
         for key, value in data.items():
             if isinstance(key, Promise):
                 key = force_text(key)
-            if isinstance(key, six.string_types) and "_" in key:
+            if isinstance(key, str) and "_" in key:
                 new_key = re.sub(camelize_re, underscore_to_camel, key)
             else:
                 new_key = key
             new_dict[new_key] = camelize(value)
         return new_dict
-    if is_iterable(data) and not isinstance(data, six.string_types):
+    if is_iterable(data) and not isinstance(data, str):
         return [camelize(item) for item in data]
     return data
 
@@ -62,7 +61,7 @@ def underscoreize(data, **options):
     if isinstance(data, dict):
         new_dict = {}
         for key, value in _get_iterable(data):
-            if isinstance(key, six.string_types):
+            if isinstance(key, str):
                 new_key = camel_to_underscore(key, **options)
             else:
                 new_key = key
@@ -74,7 +73,7 @@ def underscoreize(data, **options):
                 new_query.setlist(key, value)
             return new_query
         return new_dict
-    if is_iterable(data) and not isinstance(data, (six.string_types, File)):
+    if is_iterable(data) and not isinstance(data, (str, File)):
         return [underscoreize(item, **options) for item in data]
 
     return data

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,9 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     test_suite="tests",
 )

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from copy import deepcopy
 from unittest import TestCase
 
@@ -10,6 +8,21 @@ from django.utils.functional import lazy
 from djangorestframework_camel_case.util import camelize, underscoreize
 
 settings.configure()
+
+
+class ImportTest(TestCase):
+
+    def test_import_all(self):
+        """
+        A quick test that just imports everything, should crash in case any Django or DRF modules change
+        """
+        from djangorestframework_camel_case import parser
+        from djangorestframework_camel_case import render
+        from djangorestframework_camel_case import settings
+
+        assert parser
+        assert render
+        assert settings
 
 
 class UnderscoreToCamelTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34
+envlist = py36, py37
 
 [testenv]
 setenv =


### PR DESCRIPTION
This is my take on how to solve #61 but instead of falling back to another Six installation I dropped support for Python 2.

I don't think that it makes sense to support Python 2 anymore as both Django and DRF already dropped support for it.

Fixes #61 
Fixes #60 
Fixes #59 
Fixes #58 