### PR TITLE
Add python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=["djangorestframework_camel_case"],
     package_dir={"djangorestframework_camel_case": "djangorestframework_camel_case"},
     include_package_data=True,
+    python_requires=">=3.5",
     install_requires=[],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
Advertise that the library only supports Python 3.

In the current state of things, it is possible to install the new versions of this library on Python 2, which results in a non-working application.

Could you also republish the library on PyPI so that 1.1.1 and 1.1.0 become impossible to install on Python 2?

Thank you in advance.