### PR TITLE
Adjust regex for two scenarios that currently break:

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -41,7 +41,7 @@ def get_underscoreize_re(options):
     if options.get("no_underscore_before_number"):
         pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z](?=[a-z])))([A-Z])"
     else:
-        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z](?=[a-z])))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z]))"
+        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z0-9](?=[a-z0-9])))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z])|(?<=[A-Z])[0-9](?=[0-9]))"
     return re.compile(pattern)
 
 

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -39,9 +39,9 @@ def camelize(data):
 
 def get_underscoreize_re(options):
     if options.get("no_underscore_before_number"):
-        pattern = r"([a-z]|[0-9]+[a-z]?|[A-Z]?)([A-Z])"
+        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z](?=[a-z])))([A-Z])"
     else:
-        pattern = r"([a-z]|[0-9]+[a-z]+|[A-Z]?)([A-Z]|[0-9]+)"
+        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z](?=[a-z])))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z]))"
     return re.compile(pattern)
 
 

--- a/tests.py
+++ b/tests.py
@@ -163,6 +163,9 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "mix123123aAndLetters": 7,
             "mix123123aaAndLettersComplex": 8,
             "wordWITHCaps": 9,
+            "key10": 10,
+            "anotherKey10": 11,
+            "optionS10": 12,
         }
         query_dict.update(data)
 
@@ -178,6 +181,9 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "mix_123123a_and_letters": 7,
             "mix_123123aa_and_letters_complex": 8,
             "word_with_caps": 9,
+            "key_10": 10,
+            "another_key_10": 11,
+            "option_s_10": 12,
         }
         output_query.update(output)
         self.assertEqual(underscoreize(query_dict), output_query)

--- a/tests.py
+++ b/tests.py
@@ -35,7 +35,8 @@ class UnderscoreToCamelTestCase(TestCase):
             "b_only_one_letter": 5,
             "only_c_letter": 6,
             "mix_123123a_and_letters": 7,
-            "no_underscore_before123": 8,
+            "mix_123123aa_and_letters_complex": 8,
+            "no_underscore_before123": 9,
         }
         output = {
             "twoWord": 1,
@@ -45,7 +46,8 @@ class UnderscoreToCamelTestCase(TestCase):
             "bOnlyOneLetter": 5,
             "onlyCLetter": 6,
             "mix123123aAndLetters": 7,
-            "noUnderscoreBefore123": 8,
+            "mix123123aaAndLettersComplex": 8,
+            "noUnderscoreBefore123": 9,
         }
         self.assertEqual(camelize(data), output)
 
@@ -71,9 +73,11 @@ class CamelToUnderscoreTestCase(TestCase):
             "bOnlyOneLetter": 5,
             "onlyCLetter": 6,
             "mix123123aAndLetters": 7,
-            "key10": 8,
-            "anotherKey10": 9,
-            "optionS10": 10,
+            "mix123123aaAndLettersComplex": 8,
+            "wordWITHCaps": 9,
+            "key10": 10,
+            "anotherKey10": 11,
+            "optionS10": 12,
         }
         output = {
             "two_word": 1,
@@ -83,9 +87,11 @@ class CamelToUnderscoreTestCase(TestCase):
             "b_only_one_letter": 5,
             "only_c_letter": 6,
             "mix_123123a_and_letters": 7,
-            "key_10": 8,
-            "another_key_10": 9,
-            "option_s_10": 10,
+            "mix_123123aa_and_letters_complex": 8,
+            "word_with_caps": 9,
+            "key_10": 10,
+            "another_key_10": 11,
+            "option_s_10": 12,
         }
         self.assertEqual(underscoreize(data), output)
 
@@ -155,6 +161,8 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "bOnlyOneLetter": 5,
             "onlyCLetter": 6,
             "mix123123aAndLetters": 7,
+            "mix123123aaAndLettersComplex": 8,
+            "wordWITHCaps": 9,
         }
         query_dict.update(data)
 
@@ -168,6 +176,8 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "b_only_one_letter": 5,
             "only_c_letter": 6,
             "mix_123123a_and_letters": 7,
+            "mix_123123aa_and_letters_complex": 8,
+            "word_with_caps": 9,
         }
         output_query.update(output)
         self.assertEqual(underscoreize(query_dict), output_query)


### PR DESCRIPTION
1. Words in all caps like 'JSON' in camelCaseJSONParser.
2. Trailing lowercase letters after numbers.

Thanks for making this repo! This adjusts the regex to allow words in caps as part of camelCase. For instance `camelCaseJSONParser` should be underscoreized `camel_case_json_parser` which currently would fail.

The regex uses lookaheads and lookbehinds to fix these edge cases. It also passes all existing tests!

Hope it's appreciated, please let me know if there's anything else I can do to improve it!