### PR TITLE
Fix camelize for ReturnDicts

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -6,6 +6,8 @@ from django.http import QueryDict
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
+from rest_framework.utils.serializer_helpers import ReturnDict
+
 camelize_re = re.compile(r"[a-z0-9]?_[a-z0-9]")
 
 
@@ -22,7 +24,10 @@ def camelize(data):
     if isinstance(data, Promise):
         data = force_text(data)
     if isinstance(data, dict):
-        new_dict = OrderedDict()
+        if isinstance(data, ReturnDict):
+            new_dict = ReturnDict(serializer=data.serializer)
+        else:
+            new_dict = OrderedDict()
         for key, value in data.items():
             if isinstance(key, Promise):
                 key = force_text(key)

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from django.http import QueryDict
 from django.utils.functional import lazy
 
+from rest_framework.utils.serializer_helpers import ReturnDict
+
 from djangorestframework_camel_case.util import camelize, underscoreize
 
 settings.configure()
@@ -127,6 +129,14 @@ class PromiseStringTest(TestCase):
         self.assertEquals(camelized, {"testKey": "test_value value"})
         result = underscoreize(camelized)
         self.assertEqual(result, {"test_key": "test_value value"})
+
+
+class ReturnDictTest(TestCase):
+    def test_return_dict(self):
+        data = ReturnDict({"id": 3, "value": "val"}, serializer=object())
+        camelized = camelize(data)
+        self.assertEqual(data, camelized)
+        self.assertEqual(data.serializer, camelized.serializer)
 
 
 class GeneratorAsInputTestCase(TestCase):


### PR DESCRIPTION
The problem I'm trying to fix:

My ModelSerializer adjust the queryset for a related field based on the model instance in the __init__ method. The CamelCaseBrowsableAPIRenderer fails when it tries to render the PUT form, because camelize has removed the "serializer" attribute from the data.

This patch restores the serializer attribute on the data.