### PR TITLE
Fix regex pattern for camel_to_underscore. #73

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -46,7 +46,7 @@ def get_underscoreize_re(options):
     if options.get("no_underscore_before_number"):
         pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z](?=[a-z])))([A-Z])"
     else:
-        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z0-9](?=[a-z0-9])))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z])|(?<=[A-Z])[0-9](?=[0-9]))"
+        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z0-9](?=[a-z0-9]|$)))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z]|$)|(?<=[A-Z])[0-9](?=[0-9]|$))"
     return re.compile(pattern)
 
 

--- a/tests.py
+++ b/tests.py
@@ -77,8 +77,10 @@ class CamelToUnderscoreTestCase(TestCase):
             "mix123123aaAndLettersComplex": 8,
             "wordWITHCaps": 9,
             "key10": 10,
-            "anotherKey10": 11,
-            "optionS10": 12,
+            "anotherKey1": 11,
+            "anotherKey10": 12,
+            "optionS1": 13,
+            "optionS10": 14,
         }
         output = {
             "two_word": 1,
@@ -91,8 +93,10 @@ class CamelToUnderscoreTestCase(TestCase):
             "mix_123123aa_and_letters_complex": 8,
             "word_with_caps": 9,
             "key_10": 10,
-            "another_key_10": 11,
-            "option_s_10": 12,
+            "another_key_1": 11,
+            "another_key_10": 12,
+            "option_s_1": 13,
+            "option_s_10": 14,
         }
         self.assertEqual(underscoreize(data), output)
 
@@ -173,8 +177,10 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "mix123123aaAndLettersComplex": 8,
             "wordWITHCaps": 9,
             "key10": 10,
-            "anotherKey10": 11,
-            "optionS10": 12,
+            "anotherKey1": 11,
+            "anotherKey10": 12,
+            "optionS1": 13,
+            "optionS10": 14,
         }
         query_dict.update(data)
 
@@ -191,8 +197,10 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "mix_123123aa_and_letters_complex": 8,
             "word_with_caps": 9,
             "key_10": 10,
-            "another_key_10": 11,
-            "option_s_10": 12,
+            "another_key_1": 11,
+            "another_key_10": 12,
+            "option_s_1": 13,
+            "option_s_10": 14,
         }
         output_query.update(output)
         self.assertEqual(underscoreize(query_dict), output_query)


### PR DESCRIPTION
util.camel_to_underscore coverts:
- anotherKey1 -> another_key1
- optionS1 -> option_s1

It seems to be only an issue if it ends with a number.
After this PR, it converts:

- anotherKey1 -> another_key_1
- optionS1 -> option_s1

See detail at #73.
