### PR TITLE
Add ignore_fields option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,10 @@ settings file.
 Underscoreize Options
 =====================
 
+###########################
+No Underscore Before Number
+###########################
+
 As raised in https://github.com/krasa/StringManipulation/issues/8#issuecomment-121203018
 there are two conventions of snake case.
 
@@ -102,6 +106,44 @@ Alternatively, you can change this behavior on a class level by setting `json_un
         queryset = MyModel.objects.all()
         serializer_class = MySerializer
         parser_classes = (NoUnderscoreBeforeNumberCamelCaseJSONParser,)
+
+#############
+Ignore Fields
+#############
+
+You can also specify fields which should not have their data changed.
+The specified field(s) would still have their name change, but there would be no recursion.
+For example:
+
+.. code-block:: python
+
+    data = {"my_key": {"do_not_change": 1}}
+
+Would become:
+
+.. code-block:: python
+
+    {"myKey": {"doNotChange": 1}}
+
+However, if you set in your settings:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        "JSON_UNDERSCOREIZE": {
+            # ...
+            "ignore_fields": ("my_key",),
+            # ...
+        },
+        # ...
+    }
+
+The `my_key` field would not have its data changed:
+
+.. code-block:: python
+
+    {"myKey": {"do_not_change": 1}}
 
 =============
 Running Tests

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Underscoreize Options
 No Underscore Before Number
 ###########################
 
-As raised in https://github.com/krasa/StringManipulation/issues/8#issuecomment-121203018
+As raised in `this comment <https://github.com/krasa/StringManipulation/issues/8#issuecomment-121203018>`_
 there are two conventions of snake case.
 
 .. code-block:: text

--- a/djangorestframework_camel_case/render.py
+++ b/djangorestframework_camel_case/render.py
@@ -6,11 +6,13 @@ from djangorestframework_camel_case.util import camelize
 
 class CamelCaseJSONRenderer(api_settings.RENDERER_CLASS):
     def render(self, data, *args, **kwargs):
-        return super().render(camelize(data), *args, **kwargs)
+        return super().render(
+            camelize(data, **api_settings.JSON_UNDERSCOREIZE), *args, **kwargs
+        )
 
 
 class CamelCaseBrowsableAPIRenderer(BrowsableAPIRenderer):
     def render(self, data, *args, **kwargs):
         return super(CamelCaseBrowsableAPIRenderer, self).render(
-            camelize(data), *args, **kwargs
+            camelize(data, **api_settings.JSON_UNDERSCOREIZE), *args, **kwargs
         )

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -8,7 +8,7 @@ USER_SETTINGS = getattr(settings, "JSON_CAMEL_CASE", {})
 DEFAULTS = {
     "RENDERER_CLASS": "rest_framework.renderers.JSONRenderer",
     "PARSER_CLASS": "rest_framework.parsers.JSONParser",
-    "JSON_UNDERSCOREIZE": {"no_underscore_before_number": False},
+    "JSON_UNDERSCOREIZE": {"no_underscore_before_number": False, "ignore_fields": None},
 }
 
 # List of settings that may be in string import notation.

--- a/tests.py
+++ b/tests.py
@@ -64,7 +64,7 @@ class UnderscoreToCamelTestCase(TestCase):
         self.assertEqual(data, reference_input)
 
     def test_recursive_with_ignored_keys(self):
-        ignored_keys = ("ignore_me", "newKey")
+        ignore_fields = ("ignore_me", "new_key")
         data = {
             "ignore_me": {"no_change_recursive": 1},
             "change_me": {"change_recursive": 2},
@@ -75,7 +75,7 @@ class UnderscoreToCamelTestCase(TestCase):
             "changeMe": {"changeRecursive": 2},
             "newKey": {"also_no_change": 3},
         }
-        self.assertEqual(camelize(data, ignored_keys=ignored_keys), output)
+        self.assertEqual(camelize(data, ignore_fields=ignore_fields), output)
 
 
 class CamelToUnderscoreTestCase(TestCase):

--- a/tests.py
+++ b/tests.py
@@ -126,6 +126,20 @@ class CamelToUnderscoreTestCase(TestCase):
         underscoreize(data)
         self.assertEqual(data, reference_input)
 
+    def test_recursive_with_ignored_keys(self):
+        ignore_fields = ("ignore_me", "new_key")
+        data = {
+            "ignoreMe": {"noChangeRecursive": 1},
+            "changeMe": {"changeRecursive": 2},
+            "newKey": {"alsoNoChange": 3},
+        }
+        output = {
+            "ignore_me": {"noChangeRecursive": 1},
+            "change_me": {"change_recursive": 2},
+            "new_key": {"alsoNoChange": 3},
+        }
+        self.assertEqual(underscoreize(data, ignore_fields=ignore_fields), output)
+
 
 class NonStringKeyTest(TestCase):
     def test_non_string_key(self):

--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,20 @@ class UnderscoreToCamelTestCase(TestCase):
         camelize(data)
         self.assertEqual(data, reference_input)
 
+    def test_recursive_with_ignored_keys(self):
+        ignored_keys = ("ignore_me", "newKey")
+        data = {
+            "ignore_me": {"no_change_recursive": 1},
+            "change_me": {"change_recursive": 2},
+            "new_key": {"also_no_change": 3},
+        }
+        output = {
+            "ignoreMe": {"no_change_recursive": 1},
+            "changeMe": {"changeRecursive": 2},
+            "newKey": {"also_no_change": 3},
+        }
+        self.assertEqual(camelize(data, ignored_keys=ignored_keys), output)
+
 
 class CamelToUnderscoreTestCase(TestCase):
     def test_camel_to_under_keys(self):
@@ -130,7 +144,7 @@ class PromiseStringTest(TestCase):
     def test_promise_strings(self):
         data = {lazy_func("test_key"): lazy_func("test_value value")}
         camelized = camelize(data)
-        self.assertEquals(camelized, {"testKey": "test_value value"})
+        self.assertEqual(camelized, {"testKey": "test_value value"})
         result = underscoreize(camelized)
         self.assertEqual(result, {"test_key": "test_value value"})
 

--- a/tests.py
+++ b/tests.py
@@ -64,7 +64,7 @@ class UnderscoreToCamelTestCase(TestCase):
         self.assertEqual(data, reference_input)
 
     def test_recursive_with_ignored_keys(self):
-        ignore_fields = ("ignore_me", "new_key")
+        ignore_fields = ("ignore_me", "newKey")
         data = {
             "ignore_me": {"no_change_recursive": 1},
             "change_me": {"change_recursive": 2},
@@ -127,7 +127,7 @@ class CamelToUnderscoreTestCase(TestCase):
         self.assertEqual(data, reference_input)
 
     def test_recursive_with_ignored_keys(self):
-        ignore_fields = ("ignore_me", "new_key")
+        ignore_fields = ("ignore_me", "newKey")
         data = {
             "ignoreMe": {"noChangeRecursive": 1},
             "changeMe": {"changeRecursive": 2},


### PR DESCRIPTION
We have a use-case where we need to avoid camelizing/underscorizing certain field data. For example:
```json
{"extraData": {"FOO1": "sample", "FOO2": "example"}}
```

is underscorized as:
```json
{"extra_data": {"f_o_o_1": "sample", "f_o_o_2": "example"}}
```

Instead, by adding `extra_data` or `extraData` to `ignore_fields`, we can now get the expected behavior of underscorizing/camelizing:
```json
{"extra_data": {"FOO1": "sample", "FOO2": "example"}}
```

This relates to another PR that did this by passing the option to the constructor, but here we use the settings file to configure the option.