### PR TITLE
Add python3.8 to tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37
+envlist = py36, py37, py38
 
 [testenv]
 setenv =


### PR DESCRIPTION
All tests are passing on python 3.8

btw. Thanks for creating this super useful package!