### PR TITLE
Fix status badge on Retina displays.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django REST Framework JSON CamelCase
 ====================================
 
-.. image:: https://travis-ci.org/vbabiy/djangorestframework-camel-case.png?branch=master
+.. image:: https://travis-ci.org/vbabiy/djangorestframework-camel-case.svg?branch=master
         :target: https://travis-ci.org/vbabiy/djangorestframework-camel-case
 
 .. image:: https://badge.fury.io/py/djangorestframework-camel-case.svg


### PR DESCRIPTION
This is how it looks right now:

<img width="554" alt="Screenshot 2021-06-16 at 13 36 03" src="https://user-images.githubusercontent.com/15812620/122204496-dac2ec80-cea7-11eb-8a25-8c0e91f88d74.png">
