### PR TITLE
Fix regex pattern for camel_to_underscore.

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -51,7 +51,7 @@ def get_underscoreize_re(options):
     if options.get("no_underscore_before_number"):
         pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z](?=[a-z])))([A-Z])"
     else:
-        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z0-9](?=[a-z0-9]|$)))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z]|$)|(?<=[A-Z])[0-9](?=[0-9]|$))"
+        pattern = r"([a-z0-9]|[A-Z]?(?=[A-Z0-9](?=[a-z0-9]|(?<![A-Z])$)))([A-Z]|(?<=[a-z])[0-9](?=[0-9A-Z]|$)|(?<=[A-Z])[0-9](?=[0-9]|$))"
     return re.compile(pattern)
 
 

--- a/tests.py
+++ b/tests.py
@@ -95,6 +95,7 @@ class CamelToUnderscoreTestCase(TestCase):
             "anotherKey10": 12,
             "optionS1": 13,
             "optionS10": 14,
+            "UPPERCASE": 15,
         }
         output = {
             "two_word": 1,
@@ -111,6 +112,7 @@ class CamelToUnderscoreTestCase(TestCase):
             "another_key_10": 12,
             "option_s_1": 13,
             "option_s_10": 14,
+            "uppercase": 15,
         }
         self.assertEqual(underscoreize(data), output)
 
@@ -209,6 +211,7 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "anotherKey10": 12,
             "optionS1": 13,
             "optionS10": 14,
+            "UPPERCASE": 15,
         }
         query_dict.update(data)
 
@@ -229,6 +232,7 @@ class CamelToUnderscoreQueryDictTestCase(TestCase):
             "another_key_10": 12,
             "option_s_1": 13,
             "option_s_10": 14,
+            "uppercase": 15,
         }
         output_query.update(output)
         self.assertEqual(underscoreize(query_dict), output_query)


### PR DESCRIPTION
There's been a bug while passing a whole word set in caps to camel_to_underscore:
* WORD -> wor_d

It seems to be only an issue if it ends with an uppercase. After this PR, it should work fine:
* WORD -> word

Issue detail: #102 