### PR TITLE
Middleware to underscorize query params

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,17 @@ Add the render and parser to your django settings file.
     }
     # ...
 
+Add query param middleware to django settings file.
+
+.. code-block:: python
+
+    # ...
+    MIDDLEWARE = [
+        # Any other middleware
+        'djangorestframework_camel_case.middleware.CamelCaseMiddleWare',
+    ]
+    # ...
+
 =================
 Swapping Renderer
 =================

--- a/djangorestframework_camel_case/middleware.py
+++ b/djangorestframework_camel_case/middleware.py
@@ -1,0 +1,16 @@
+from djangorestframework_camel_case.settings import api_settings
+from djangorestframework_camel_case.util import underscoreize
+
+class CamelCaseMiddleWare:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.GET = underscoreize(
+            request.GET,
+            **api_settings.JSON_UNDERSCOREIZE
+        )
+
+        response = self.get_response(request)
+        return response


### PR DESCRIPTION
Adds the missing unit test to the middleware written by @reyzavk in #68 

Documentation updated to include query param readme during installation.