### PR TITLE
Drop Django 2.2 Support and Bump minimum Python to 3.6

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include AUTHORS.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-djangorestframework>=2.0.0
-django>=2.2
+djangorestframework>=3.13.0
+django>=3.2

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 
 try:
@@ -18,6 +19,10 @@ readme = open("README.rst").read()
 history = open("HISTORY.rst").read().replace(".. :changelog:", "")
 import djangorestframework_camel_case
 
+def extract_requires():
+    with Path('requirements.txt').open() as reqs:
+        return [req.strip() for req in reqs if not req.startswith(("#", "--", "-r")) and req.strip()]
+
 setup(
     name="djangorestframework-camel-case",
     version=djangorestframework_camel_case.__version__,
@@ -31,7 +36,7 @@ setup(
     package_dir={"djangorestframework_camel_case": "djangorestframework_camel_case"},
     include_package_data=True,
     python_requires=">=3.6",
-    install_requires=[],
+    install_requires=extract_requires(),
     license="BSD",
     zip_safe=False,
     keywords="djangorestframework_camel_case",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=["djangorestframework_camel_case"],
     package_dir={"djangorestframework_camel_case": "djangorestframework_camel_case"},
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
Django 3.2 is currently the oldest supported Django version. Django Rest Framework added Django 3.2 support officially with https://github.com/encode/django-rest-framework/commit/e92016ac2e926483e05e296558fc3d1ea3279625, which first appears in DRF 3.13.0.

The lowest Python version supported by Django 3.2 and DRF 3.13.0 is Python 3.6, https://docs.djangoproject.com/en/3.2/releases/3.2/, so the `install_requires` was updated to reflect that. Tests are currently not run on anything below Python 3.6 currently, so this change also makes since from what is being tested too.