### PR TITLE
Fix incorrect placement of JSON_UNDERSCOREIZE in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ By default, the package uses the first case. To use the second case, specify it 
 
 .. code-block:: python
 
-    REST_FRAMEWORK = {
+    JSON_CAMEL_CASE = {
         # ...
         'JSON_UNDERSCOREIZE': {
             'no_underscore_before_number': True,
@@ -144,7 +144,7 @@ However, if you set in your settings:
 
 .. code-block:: python
 
-    REST_FRAMEWORK = {
+    JSON_CAMEL_CASE = {
         # ...
         "JSON_UNDERSCOREIZE": {
             # ...
@@ -182,7 +182,7 @@ However, if you set in your settings:
 
 .. code-block:: python
 
-    REST_FRAMEWORK = {
+    JSON_CAMEL_CASE = {
         # ...
         "JSON_UNDERSCOREIZE": {
             # ...


### PR DESCRIPTION
JSON_UNDERSCOREIZE should be under JSON_CAMEL_CASE and not REST_FRAMEWORK