### PR TITLE
Allow use of ORJSONParser

### DIFF
--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -21,7 +21,10 @@ VALID_SETTINGS = {
         "drf_ujson.renderers.UJSONRenderer",
         "rest_framework.renderers.UnicodeJSONRenderer",
     ),
-    "PARSER_CLASS": ("rest_framework.parsers.JSONParser",),
+    "PARSER_CLASS": (
+        "rest_framework.parsers.JSONParser",
+        "drf_orjson_renderer.parsers.ORJSONParser",
+    ),
 }
 
 


### PR DESCRIPTION
Fixes #144 

Tested manually by setting the orjson render/parser as the default in `settings.py`: not sure if there's another way to be doing that/including it in the tests