### PR TITLE
Update tested versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,17 +13,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11","3.12"]
+        python-version:
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.2.2
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install tox tox-gh-actions
-      - name: Test with tox
-        run: tox
+          pip install tox
+
+      - name: Run tox targets for ${{ matrix.python-version }}
+        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
+django>=4.2
 djangorestframework>=3.13.0
-django>=3.2

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,15 @@ readme = open("README.rst").read()
 history = open("HISTORY.rst").read().replace(".. :changelog:", "")
 import djangorestframework_camel_case
 
+
 def extract_requires():
-    with Path('requirements.txt').open() as reqs:
-        return [req.strip() for req in reqs if not req.startswith(("#", "--", "-r")) and req.strip()]
+    with Path("requirements.txt").open() as reqs:
+        return [
+            req.strip()
+            for req in reqs
+            if not req.startswith(("#", "--", "-r")) and req.strip()
+        ]
+
 
 setup(
     name="djangorestframework-camel-case",
@@ -31,23 +37,21 @@ setup(
     packages=["djangorestframework_camel_case"],
     package_dir={"djangorestframework_camel_case": "djangorestframework_camel_case"},
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=extract_requires(),
     license="BSD",
     zip_safe=False,
     keywords="djangorestframework_camel_case",
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
-    test_suite="tests",
 )

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from unittest import TestCase, mock
+from unittest import TestCase, main, mock
 
 from django.conf import settings
 from django.http import QueryDict
@@ -325,3 +325,7 @@ class CamelCaseMiddleWareTestCase(TestCase):
         middleware(request)
         (args, kwargs) = get_response_mock.call_args
         self.assertEqual(args[0].GET, output_query)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,32 @@
 [tox]
-envlist = py37, py38, py39, py310, py311, py312
+envlist =
+    py39-django{42}
+    py310-django{50, 51, 52}
+    py311-django{50, 51, 52}
+    py312-django{50, 51, 52}
+    py313-django{51, 52}
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/djangorestframework-camel-case
-commands = python setup.py test
+commands =
+    python \
+      -W error::ResourceWarning \
+      -W error::DeprecationWarning \
+      -W error::PendingDeprecationWarning \
+      tests.py
 deps =
     -r{toxinidir}/requirements.txt
     setuptools
+    django42: Django>=4.2a1,<5.0
+    django50: Django>=5.0a1,<5.1
+    django51: Django>=5.1a1,<5.2
+    django52: Django>=5.2a1,<6.0


### PR DESCRIPTION
Made these version changes:

1. Drop EOL Python versions 3.7 and 3.8.
2. Add Python 3.13.
3. Drop Django 3.2, 4.0, and 4.1.
4. Add Django up to 5.2 (currently in beta, [expected April](https://docs.djangoproject.com/en/5.2/releases/5.2/)).

On the way, I made these extra testing changes:

1. Fixed `tox` to run `tests.py` directly. The `setup.py test` command was removed in [setuptools 72.0.0](https://setuptools.pypa.io/en/latest/history.html#v72-0-0). This is a fine replacement for now.
2. Made tox run per-Django-version tests.
3. Made GitHub Actions run all configured Django versions’ tests per Python version. This is a pattern I use in my own projects ([example](https://github.com/adamchainz/django-htmx/blob/main/.github/workflows/main.yml)) that allows tests to run in parallel without repeating the matrix in GitHub Actions. For small test suites, it ends up being faster than one job per Python + Django version, because of caching.