### PR TITLE
Shallow ignore keys of object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,26 @@ The `unchanging_key` field would not be renamed:
 
     {"unchanging_key": {"changeMe": 1}}
 
+You can also ignore only one level in a nested object using `ignore_shallow_keys`:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        "JSON_UNDERSCOREIZE": {
+            # ...
+            "ignore_shallow_keys": ("nested_object",),
+            # ...
+        },
+        # ...
+    }
+
+The `nested_object` field's immediate children would not be renamed, but deeper levels would still be camelized:
+
+.. code-block:: python
+
+    {"nestedObject": {"first_level": {"secondLevel": 1}}}
+
 ignore_keys and ignore_fields can be applied to the same key if required.
 
 =============

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -20,10 +20,11 @@ def underscore_to_camel(match):
         return group[1].upper()
 
 
-def camelize(data, **options):
+def camelize(data, parent_key=None, **options):
     # Handle lazy translated strings.
     ignore_fields = options.get("ignore_fields") or ()
     ignore_keys = options.get("ignore_keys") or ()
+    ignore_shallow_keys = options.get("ignore_shallow_keys") or ()
     if isinstance(data, Promise):
         data = force_str(data)
     if isinstance(data, dict):
@@ -39,11 +40,18 @@ def camelize(data, **options):
             else:
                 new_key = key
 
-            if key not in ignore_fields and new_key not in ignore_fields:
-                result = camelize(value, **options)
+            if parent_key in ignore_shallow_keys or new_key in ignore_shallow_keys:
+                result = camelize(value, parent_key=key, **options)
+            elif key not in ignore_fields and new_key not in ignore_fields:
+                result = camelize(value, parent_key=key, **options)
             else:
                 result = value
-            if key in ignore_keys or new_key in ignore_keys:
+            print(f"key: {key}, new key: {new_key}, parent key: {parent_key}")
+            if (
+                key in ignore_keys
+                or new_key in ignore_keys
+                or parent_key in ignore_shallow_keys
+            ):
                 new_dict[key] = result
             else:
                 new_dict[new_key] = result

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -46,7 +46,6 @@ def camelize(data, parent_key=None, **options):
                 result = camelize(value, parent_key=key, **options)
             else:
                 result = value
-            print(f"key: {key}, new key: {new_key}, parent key: {parent_key}")
             if (
                 key in ignore_keys
                 or new_key in ignore_keys

--- a/tests.py
+++ b/tests.py
@@ -89,6 +89,46 @@ class UnderscoreToCamelTestCase(TestCase):
         }
         self.assertEqual(camelize(data, ignore_fields=ignore_fields, ignore_keys=ignore_keys), output)
 
+    def test_camelize_with_ignore_shallow_keys(self):
+        ignore_shallow_keys = ("shallow_ignored", "another_shallow")
+        data = {
+            "shallow_ignored": {
+                "first_level_stays": {
+                    "second_level_gets_camelized": 1
+                }
+            },
+            "another_shallow": {
+                "also_stays": {
+                    "nested_gets_camelized": 2,
+                    "another_nested": {
+                        "deeply_nested_also_camelized": 3
+                    }
+                }
+            },
+            "normal_key": {
+                "gets_camelized": 4
+            }
+        }
+        output = {
+            "shallowIgnored": {
+                "first_level_stays": {
+                    "secondLevelGetsCamelized": 1
+                }
+            },
+            "anotherShallow": {
+                "also_stays": {
+                    "nestedGetsCamelized": 2,
+                    "anotherNested": {
+                        "deeplyNestedAlsoCamelized": 3
+                    }
+                }
+            },
+            "normalKey": {
+                "getsCamelized": 4
+            }
+        }
+        self.assertEqual(camelize(data, ignore_shallow_keys=ignore_shallow_keys), output)
+
 
 class CamelToUnderscoreTestCase(TestCase):
     def test_camel_to_under_keys(self):


### PR DESCRIPTION
Added option to ignore shallow keys of an object, but still camelize the nested data.