### PR TITLE
Remove unnecessary OrderedDict from camelize

### DIFF
--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -1,5 +1,4 @@
 import re
-from collections import OrderedDict
 
 from django.core.files import File
 from django.http import QueryDict
@@ -30,7 +29,7 @@ def camelize(data, **options):
         if isinstance(data, ReturnDict):
             new_dict = ReturnDict(serializer=data.serializer)
         else:
-            new_dict = OrderedDict()
+            new_dict = {}
         for key, value in data.items():
             if isinstance(key, Promise):
                 key = force_str(key)


### PR DESCRIPTION
## Summary
- Replace `OrderedDict()` with plain `{}` in `camelize()` (line 33)
- Remove unused `from collections import OrderedDict` import

## Motivation
Python 3.7+ dicts maintain insertion order, making `OrderedDict` unnecessary. The `underscoreize` function (line 80) already uses plain `dict`.

Using `OrderedDict` causes `OrderedDict(...)` to appear in logs and repr output, making debugging harder with no benefit.

## Backward compatibility
This is fully backward compatible - `dict` supports all the same operations used in the function. The only observable difference is `repr()` output, which is the desired improvement.