### PR TITLE
Allow subclass-provided settings on CamelCaseBrowsableAPIRenderer

### DIFF
--- a/djangorestframework_camel_case/render.py
+++ b/djangorestframework_camel_case/render.py
@@ -14,7 +14,9 @@ class CamelCaseJSONRenderer(api_settings.RENDERER_CLASS):
 
 
 class CamelCaseBrowsableAPIRenderer(BrowsableAPIRenderer):
+    json_underscoreize = api_settings.JSON_UNDERSCOREIZE
+
     def render(self, data, *args, **kwargs):
         return super(CamelCaseBrowsableAPIRenderer, self).render(
-            camelize(data, **api_settings.JSON_UNDERSCOREIZE), *args, **kwargs
+            camelize(data, **self.json_underscoreize), *args, **kwargs
         )


### PR DESCRIPTION
Addresses issue https://github.com/vbabiy/djangorestframework-camel-case/issues/164